### PR TITLE
Unnecessary stream eliminated

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const stream = require('stream');
 const s3Wrapper = require('./s3Wrapper');
 const GetObjectStream = require('./getObjectStream');
 
@@ -27,16 +26,12 @@ module.exports = {
 	},
 	uploadStream: (streamToUpload, params, options) => {
 		return new Promise((resolve, reject) => {
-			streamToUpload.pipe((() => {
-				const pass = new stream.PassThrough({ objectMode: true });
-				s3Wrapper.upload({ ...params, Body: pass }, options, (error, data) => {
-					if(error)
-						reject(error);
+			return s3Wrapper.upload({ ...params, Body: streamToUpload }, options, (error, data) => {
+				if(error)
+					reject(error);
 
-					resolve(data);
-				});
-				return pass;
-			})());
+				resolve(data);
+			});
 		});
 	},
 	GetObjectStream

--- a/tests/s3-test.js
+++ b/tests/s3-test.js
@@ -473,6 +473,7 @@ describe('S3', () => {
 		});
 
 		it('Should return the uploaded object info', async () => {
+
 			const response = {
 				ETag: '"a30c37a2ccde6cf699f557353762815b"',
 				Location: 'https://test.s3.amazonaws.com/test.csv',
@@ -491,7 +492,6 @@ describe('S3', () => {
 
 			assert.deepStrictEqual(await S3.uploadStream(testStream, s3Params), response);
 		});
-
 
 	});
 


### PR DESCRIPTION
Se hicieron pruebas reales contra S3 y se detecto que el upload nunca resuelve, al eliminar el stream que se crea dentro del método y llamando al wrapper directo pasa a funcionar correctamente.