### PR TITLE
JCN-432 Modificar get object para retornar buffer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
 	},
 
 	rules: {
+		strict: ['error', 'global'],
 		'operator-linebreak': 0,
 		'no-continue': 0,
 		'no-plusplus': 0,
@@ -38,7 +39,7 @@ module.exports = {
 		'prefer-template': 0,
 		'import/no-unresolved': 0,
 		'import/no-extraneous-dependencies': ['error', { devDependencies: ['**/tests/**/*.js'] }],
-
+		'import/extensions': 0,
 		'no-bitwise': 0,
 
 		curly: ['error', 'multi-or-nest'],
@@ -118,6 +119,8 @@ module.exports = {
 			ObjectExpression: { minProperties: 5, multiline: true, consistent: true },
 			ObjectPattern: { minProperties: 5, multiline: true, consistent: true }
 		}],
-		'nonblock-statement-body-position': ['error', 'below', { overrides: { else: 'any' } }]
+		'nonblock-statement-body-position': ['error', 'below', { overrides: { else: 'any' } }],
+
+		'default-param-last': 0
 	}
 };

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/coverage-status.yml
+++ b/.github/workflows/coverage-status.yml
@@ -11,10 +11,10 @@ jobs:
 
     - uses: actions/checkout@v1
 
-    - name: Use Node.js 14.x
+    - name: Use Node.js 18.x
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 18.x
 
     - name: npm install, make test-coverage
       run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
       - run: npm i
       - run: npm test
 
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 18
           registry-url: https://registry.npmjs.org/
       - run: npm i
       - run: npm publish --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## Unreleased
+### Added
+- `S3.getObjectRaw` if you want the original AWS response for `getObject`, you will receive a Readable object in `Body` property.
+
+### Changed
+- `S3.getObject` method returns a Buffer type in `Body` property.
 ## [2.0.0] - 2023-03-03
 ### Changed
 - Migrate `AWS SDK` to `V3` version

--- a/README.md
+++ b/README.md
@@ -13,11 +13,14 @@ npm install @janiscommerce/s3
 ## Description
 This is a wrapper for the AWS SDK for the management S3 request, that makes easier the use of it.
 
-For more information read the [AWS S3 SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html)
+For more information read the [AWS S3 SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/index.html).
+
+> Since `v2.0.0` you need Node 18
 
 The possible methods are:
 
 * `getObject`
+* `getObjectRaw`
 * `putObject`
 * `headObject`
 * `copyObject`
@@ -29,6 +32,14 @@ The possible methods are:
 * `deleteBucket`
 * `getSignedUrl`
 * `createPresignedPost`
+
+### getObject
+
+Since the package updates to use SDK v3 and Node-18 compatibility, when use `getObject`, it returns the `Body` as an `Readable` type. This change is not compatible with previous uses.
+
+So `getObject` method convert the `Body` into a `Buffer` type object, to keep the compatibility with previous uses.
+
+> If you wanted the original behavior, you can use `getObjectRaw`.
 
 ## Usage
 ```js

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -18,8 +18,29 @@ const {
 
 const GetObjectStream = require('./getObjectStream');
 
+const getObject = async params => {
+	const { Body, ...response } = await S3Client.send(new GetObjectCommand(params));
+
+	let bodyBuffered;
+
+	try {
+		// BODY is Readable type; since Node 17+ can convert this new type using Readable.toArray API and Buffer.concat
+		bodyBuffered = Buffer.concat(await Body.toArray());
+
+	} catch(error) {
+		// If Body is empty will throw;
+		bodyBuffered = null;
+	}
+
+	return {
+		...response,
+		Body: bodyBuffered
+	};
+};
+
 module.exports = {
-	getObject: params => S3Client.send(new GetObjectCommand(params)),
+	getObject,
+	getObjectRaw: params => S3Client.send(new GetObjectCommand(params)),
 	putObject: params => S3Client.send(new PutObjectCommand(params)),
 	deleteObject: params => S3Client.send(new DeleteObjectCommand(params)),
 	deleteObjects: params => S3Client.send(new DeleteObjectsCommand(params)),

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "homepage": "https://github.com/janis-commerce/s3.git#readme",
   "devDependencies": {
     "aws-sdk-client-mock": "^2.0.1",
-    "eslint": "^8.35.0",
-    "eslint-config-airbnb-base": "^13.1.0",
+    "eslint": "^8.42.0",
+    "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.27.5",
     "husky": "^8.0.3",
     "mocha": "^10.2.0",


### PR DESCRIPTION
**LINK AL TICKET**
https://janiscommerce.atlassian.net/browse/JCN-431

**DESCRIPCIÓN DEL REQUERIMIENTO**
Se necesita actualizar el package de [S3](https://github.com/janis-commerce/s3) para que al usar el método de getObject en la propiedad Body sea de tipo Buffer .

A raiz de la actualización al uso del SDK v3 de AWS, esta propiedad llega en formato [Readable](https://nodejs.org/api/stream.html#class-streamreadable) , este formato hace que todos los usos en Janis salgan mal generar todo tipo de errores.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se modificó el metodo `S3.getObject` para que retorne un Buffer en el Body. 
También se agregó un método `S3.getObjectRaw` para que funcione con la respuesta original.