### PR TITLE
Jcn 453 fix upload stream

### DIFF
--- a/lib/s3.js
+++ b/lib/s3.js
@@ -52,12 +52,10 @@ module.exports = {
 	copyObject: params => S3Client.send(new CopyObjectCommand(params)),
 	getSignedUrl: (params, options = {}) => s3Wrapper.getSignedUrl(S3Client, new GetObjectCommand(params), options),
 	createPresignedPost: params => s3Wrapper.createPresignedPost(S3Client, params),
-	uploadStream: (streamToUpload, params, options) => {
-		return s3Wrapper.Upload({
-			client: S3Client,
-			params: { ...params, Body: streamToUpload },
-			...options
-		});
-	},
+	uploadStream: (streamToUpload, params, options) => s3Wrapper.Upload({
+		client: S3Client,
+		params: { ...params, Body: streamToUpload },
+		...options
+	}),
 	GetObjectStream
 };

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -52,7 +52,7 @@ module.exports = {
 	copyObject: params => S3Client.send(new CopyObjectCommand(params)),
 	getSignedUrl: (params, options = {}) => s3Wrapper.getSignedUrl(S3Client, new GetObjectCommand(params), options),
 	createPresignedPost: params => s3Wrapper.createPresignedPost(S3Client, params),
-	uploadStream: async (streamToUpload, params, options) => {
+	uploadStream: (streamToUpload, params, options) => {
 		return s3Wrapper.Upload({
 			client: S3Client,
 			params: { ...params, Body: streamToUpload },

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -53,7 +53,7 @@ module.exports = {
 	getSignedUrl: (params, options = {}) => s3Wrapper.getSignedUrl(S3Client, new GetObjectCommand(params), options),
 	createPresignedPost: params => s3Wrapper.createPresignedPost(S3Client, params),
 	uploadStream: async (streamToUpload, params, options) => {
-		return new s3Wrapper.Upload({
+		return s3Wrapper.Upload({
 			client: S3Client,
 			params: { ...params, Body: streamToUpload },
 			...options

--- a/lib/s3Wrapper.js
+++ b/lib/s3Wrapper.js
@@ -42,5 +42,5 @@ module.exports = {
 	CopyObjectCommand,
 	getSignedUrl: /* istanbul ignore next */ (...args) => getSignedUrl(...args),
 	createPresignedPost: /* istanbul ignore next */ (...args) => createPresignedPost(...args),
-	Upload: /* istanbul ignore next */ (...args) => Upload(...args)
+	Upload: /* istanbul ignore next */ (...args) => new Upload(...args)
 };


### PR DESCRIPTION
Data lake usa `uploadStream` y empezó a dar error al actualizar la versión, de que Upload no era un constructor, revisando el paquete se detecto que había cambiado como se llamaba al `Upload` del SDK y por eso estaba dando error.

PD: ya esta probado en data lake y funciono ok